### PR TITLE
remove 'file:' prefix for pip

### DIFF
--- a/{{cookiecutter.repository_name}}/requirements/environment.yml
+++ b/{{cookiecutter.repository_name}}/requirements/environment.yml
@@ -7,4 +7,4 @@ dependencies:
   - pip
   - pip:
     - hydra-core
-    - -r file:dev-requirements.txt
+    - -r dev-requirements.txt


### PR DESCRIPTION
As stated in [](url) #14  , there seems to be a change to `pip` syntax, so that it would no longer work with the `file:` prefix.
